### PR TITLE
add support for PJAXResponseMixin to support sub-classes defining get_pjax_template_name as an alternate to defining pjax_template_name

### DIFF
--- a/djpjax.py
+++ b/djpjax.py
@@ -58,7 +58,9 @@ class PJAXResponseMixin(TemplateResponseMixin):
     def get_template_names(self):
         names = super(PJAXResponseMixin, self).get_template_names()
         if self.request.META.get('HTTP_X_PJAX', False):
-            if self.pjax_template_name:
+            if hasattr(self, 'get_pjax_template_name'):
+                names = [self.get_pjax_template_name()]
+            elif self.pjax_template_name:
                 names = [self.pjax_template_name]
             else:
                 names = _pjaxify_template_var(names)


### PR DESCRIPTION
Allows a callable to be defined on PJAXResponseMixin subclasses for instances where the pjax template name must be defined dynamically, such as in instances where it is based on the request.
